### PR TITLE
魚眼レンズ対応ドキュメントの追加とHANDOVER.mdのgitignore登録

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+HANDOVER.md

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ PixInsightの ImageSolver では対応できない超広角な範囲の星空画
 - **ビュー状態の保持**: PixInsightで編集中（ストレッチ、ABE等適用後）の画像に対してソルブしても、ピクセルデータと処理履歴を維持したままWCSを適用
 - **XISF/FITS対応**: PixInsightネイティブのXISF形式とFITS形式の両方に完全対応
 - **自動形式判定**: 入力ファイルの形式を自動判定し、同じ形式で出力
+- **魚眼レンズ対応**: equisolid/equidistant/stereographic投影に対応し、対角180°超のFOVでもソルブ可能
 
 ## 必要な環境
 
@@ -162,6 +163,7 @@ done
 
 | レンズ焦点距離 | FOV (フルサイズ) | 必要なインデックス |
 |--------------|-----------------|------------------|
+| 15mm (魚眼) | ~183° | 4107, 4110 ~ 4119, 4208 ~ 4219 |
 | 24mm | ~74° | 4110 ~ 4119 |
 | 35mm | ~54° | 4110 ~ 4119 |
 | 50mm | ~40° | 4112 ~ 4118 |
@@ -199,8 +201,9 @@ PixInsight を再起動し、**Script > Utilities > SplitImageSolver** から実
 3. Settings で Python パスを設定: `.venv/bin/python` のフルパス
 4. Script Directory にリポジトリのルートパスを設定
 5. **Focal Length**（焦点距離 mm）と **Pixel Pitch**（ピクセルピッチ μm）を入力
-6. Grid を **3x3**（広角レンズ推奨）に設定
-7. 「Execute」をクリック
+6. 魚眼レンズの場合は **Fisheye lens** チェックボックスをON（機材DBに登録済みの魚眼レンズは自動でONになります）
+7. Grid を推奨サイズに設定（ダイアログに表示される推奨値を参考に。魚眼レンズでは12x8や10x10が推奨されます）
+8. 「Execute」をクリック
 
 詳細なパラメータ説明は [PixInsight スクリプト README](javascript/README.md) を参照してください。
 
@@ -230,9 +233,11 @@ python3 python/main.py \
 
 **FOV/座標ヒント:**
 - `--focal-length MM`: 焦点距離 (mm) - FOV計算に使用
+- `--pixel-pitch UM`: ピクセルピッチ (μm) - 機材DBにないカメラの場合に指定
 - `--pixel-scale ARCSEC`: ピクセルスケール (arcsec/pixel) - 直接指定する場合
 - `--ra DEG`: 視野中心の赤経 (degrees)
 - `--dec DEG`: 視野中心の赤緯 (degrees)
+- `--lens-type TYPE`: レンズ投影型 (rectilinear, fisheye_equisolid, fisheye_equidistant, fisheye_stereographic) [デフォルト: rectilinear]
 
 **WCS統合設定:**
 - `--wcs-method METHOD`: 統合方法 (weighted_least_squares | central_tile) [デフォルト: weighted_least_squares]
@@ -269,7 +274,23 @@ python3 python/main.py \
   --ra 98.0 --dec 5.0
 ```
 
-**例3: 詳細ログ出力**
+**例3: 魚眼レンズ（Sigma 15mm Fisheye + Sony A7R IV）**
+
+```bash
+python3 python/main.py \
+  --input fisheye_image.xisf \
+  --output solved_fisheye.xisf \
+  --grid 12x8 \
+  --overlap 150 \
+  --focal-length 15 \
+  --pixel-pitch 3.76 \
+  --ra 276.0 --dec -24.0 \
+  --lens-type fisheye_equisolid
+```
+
+魚眼レンズでは `--lens-type fisheye_equisolid` を指定することで、equisolid（等立体角）投影に基づく正確なFOV計算・スケールヒントが使われます。機材DBに登録済みのレンズは `--lens` 指定で自動検出されます。
+
+**例4: 詳細ログ出力**
 
 ```bash
 python3 python/main.py \
@@ -380,6 +401,16 @@ Overlap validation failed: max error = 10.5" (tolerance = 5.0")
 
 - 超広角レンズの歪みが大きい場合、WCS精度が低下する可能性がある
 - 大きな画像（8000x6000以上）では大量のメモリを使用
+
+### 低解像度・超広角カメラ（ATOM Cam 2 等）について
+
+ATOM Cam 2 のような監視カメラ系デバイス（1920×1080, 対角120° FOV, ピクセルスケール~191"/px）は、魚眼投影対応後もプレートソルブが困難です。
+
+**インデックスファイルの問題**: この解像度では astrometry.net の 4200-4207 シリーズ（超広角用）が必要ですが、これらは healpix 分割で配布されており全天カバーに数十GBのダウンロードが必要です。また、より小スケールの 4100-4106 シリーズは公式サーバー（`data.astrometry.net/4100/`）に存在しません。
+
+**解像度の問題**: ~191"/px では1ピクセルが約3角分に相当し、solve-field が星のパターンマッチングに使える星の数が極めて限られます。タイル分割するとさらに1タイルあたりの星数が減少し、信頼性の高いソルブが困難になります。
+
+対象天域の healpix タイルのみをダウンロードすれば原理的には可能ですが、実用的なワークフローとしては現時点で未検証です。
 
 ## ライセンス
 

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -75,7 +75,9 @@ pixel_scale [arcsec/px] = 206.265 × pixel_pitch [μm] / focal_length [mm]
 
 | 対角FOV | 推奨グリッド | 対象レンズ例 |
 |---------|-------------|-------------|
-| > 90° | 8x8 | 14mm |
+| > 150° | 12x8 | 15mm 魚眼 |
+| 120°–150° | 10x10 | 8mm 魚眼 |
+| 90°–120° | 8x8 | 14mm |
 | 60°–90° | 5x5 | 20–24mm |
 | 30°–60° | 3x3 | 35–50mm |
 | ≤ 30° | 2x2 | 85mm以上 |
@@ -114,13 +116,13 @@ solve-field --overwrite --no-plots --no-remove-lines --no-verify-uniformize \
 
 #### タイルごとのパラメータ最適化
 
-**実効ピクセルスケール**（後述の「gnomonic投影補正」で詳述）:
+**実効ピクセルスケール**（後述の「投影型対応とスケール補正」で詳述）:
 
-各タイルの中心位置に基づき、画像中心からの角度に応じたスケール倍率を算出します。
+各タイルの中心位置と投影型に基づき、画像中心からの角度に応じたスケール倍率を算出します。
 
 ```python
-effective_scale = center_scale / cos²(θ)
-# θ = arctan(r_pixels × center_scale_rad)
+θ = _pixel_radius_to_angle(r_pixels, center_scale_rad, projection)
+effective_scale = center_scale × _effective_pixel_scale_factor(θ, projection)
 ```
 
 **動的マージン計算**:
@@ -134,7 +136,7 @@ scale_margin = 0.2 + 0.3 × r_ratio  # 中心: ±20%, コーナー: ±50%
 
 **RA/DECヒント**:
 
-画像中心のRA/DECが既知の場合、gnomonic逆投影によりタイルごとの中心座標を算出してヒントとして渡します（詳細は後述）。
+画像中心のRA/DECが既知の場合、投影型に応じた逆投影によりタイルごとの中心座標を算出してヒントとして渡します（詳細は後述）。
 
 #### 自動ダウンサンプリング
 
@@ -273,40 +275,76 @@ else:
 
 ---
 
-## 3. gnomonic（正距）投影補正
+## 3. 投影型対応とスケール補正
 
-広角画像のプレートソルブにおいて最も重要な技術的課題は、TAN（gnomonic）投影の非線形性への対処です。
+広角画像のプレートソルブにおいて最も重要な技術的課題は、レンズ投影型の非線形性への対処です。本ツールは4つの投影型をサポートしています。
 
-### 3.1 問題: 非一様なピクセルスケール
+### 3.1 サポートする投影型
 
-gnomonic投影では、光軸（画像中心）から離れるほどピクセルあたりの天球上の角度が大きくなります。
+| 投影型 | レンズ種別 | r(θ) の式 | スケール倍率 dθ/dr | CLIでの指定値 |
+|--------|-----------|-----------|-------------------|-------------|
+| gnomonic | rectilinear（通常レンズ） | r = tan(θ)/s | 1/cos²(θ) | `rectilinear` |
+| equisolid | 対角魚眼（大半の魚眼レンズ） | r = 2·sin(θ/2)/s | 1/cos(θ/2) | `fisheye_equisolid` |
+| equidistant | 円周魚眼 | r = θ/s | 1（一定） | `fisheye_equidistant` |
+| stereographic | 一部の魚眼 | r = 2·tan(θ/2)/s | 1/cos²(θ/2) | `fisheye_stereographic` |
+
+ここで r はピクセル距離、θ は光軸からの角距離、s は中心ピクセルスケール (rad/pixel) です。
+
+**投影型の指定方法:**
+
+- `--lens-type` CLI引数で明示指定
+- `--lens` で機材DBに登録済みレンズを指定すると `type` フィールドから自動検出
+- PixInsightでは **Fisheye lens** チェックボックス、または機材DB自動マッチングで検出
+- デフォルトは `rectilinear`（gnomonic）で後方互換性を維持
+
+### 3.2 問題: 非一様なピクセルスケール
+
+全ての投影型で、光軸（画像中心）から離れるほどピクセルあたりの天球上の角度が変化します。変化の大きさは投影型によって異なります。
 
 ```
-14mm + α7RV の場合:
+14mm rectilinear + α7RV の場合:
   中心:        54.4 arcsec/pixel
   エッジ:      87–95 arcsec/pixel（1.6–1.7倍）
   コーナー:    ~113 arcsec/pixel（2.1倍）
+
+15mm fisheye (equisolid) + α7RIV の場合:
+  中心:        51.7 arcsec/pixel
+  エッジ:      62–66 arcsec/pixel（1.2–1.3倍）
+  コーナー:    ~66 arcsec/pixel（1.3倍）
 ```
+
+gnomonic投影は端でスケールが急激に増大しますが、equisolid投影はより緩やかです。equidistant投影ではスケール倍率が常に1.0（一定）です。
 
 この非線形性を無視して一律のピクセルスケールヒントを solve-field に渡すと、端タイルのスケール範囲が実際の値と合わず、ソルブに失敗します。
 
-### 3.2 タイルごとの実効ピクセルスケール計算
+### 3.3 タイルごとの実効ピクセルスケール計算
 
-`python/utils/coordinate_transform.py` の `calculate_tile_pixel_scale()` で、各タイル位置での実効スケールを計算します。
+`python/utils/coordinate_transform.py` の `calculate_tile_pixel_scale()` で、投影型に応じた実効スケールを計算します。
 
-**数式:**
+**計算フロー:**
 
 ```
 r = √((tile_x - center_x)² + (tile_y - center_y)²)   [pixels]
-θ = arctan(r × scale_center_rad)                        [radians]
-scale_effective = scale_center / cos²(θ)                 [arcsec/pixel]
+
+# Step 1: 投影型に応じた角距離θを計算 (_pixel_radius_to_angle)
+gnomonic:       θ = arctan(r × s)
+equisolid:      θ = 2 × arcsin(r × s / 2)    ※ arcsin引数をclamp(-1, 1)
+equidistant:    θ = r × s
+stereographic:  θ = 2 × arctan(r × s / 2)
+
+# Step 2: 投影型に応じたスケール倍率を計算 (_effective_pixel_scale_factor)
+gnomonic:       factor = 1 / cos²(θ)
+equisolid:      factor = 1 / cos(θ/2)
+equidistant:    factor = 1
+stereographic:  factor = 1 / cos²(θ/2)
+
+# Step 3: 実効スケール
+scale_effective = scale_center × factor   [arcsec/pixel]
 ```
 
-`cos²(θ)` による除算は、gnomonic投影の固有の非線形性（接平面への投影による面積拡大）を正確に表現します。
+### 3.4 投影型対応のRA/DECヒント計算
 
-### 3.3 gnomonic逆投影によるRA/DECヒント計算
-
-画像中心の天球座標(α₀, δ₀)が既知の場合、任意のタイル中心のRA/DECを球面三角法で算出します。
+画像中心の天球座標(α₀, δ₀)が既知の場合、投影型に応じた逆投影で任意のタイル中心のRA/DECを算出します。
 
 `python/utils/coordinate_transform.py` の `pixel_offset_to_radec()`:
 
@@ -314,19 +352,21 @@ scale_effective = scale_center / cos²(θ)                 [arcsec/pixel]
 入力: (α₀, δ₀) = 画像中心の天球座標
       (Δx, Δy) = 画像中心からのピクセルオフセット
       s = 中心ピクセルスケール [arcsec/pixel]
+      projection = 投影型
 
-Step 1: 接平面座標（標準座標）に変換
-  ξ = Δx × s_rad    （東が正）
-  η = Δy × s_rad    （北が正）
+Step 1: 方位角φと画像面上の距離rを計算
+  r = √(Δx² + Δy²)
+  φ = arctan2(Δx, Δy)
 
-Step 2: 中心からの角距離
-  ρ = √(ξ² + η²)
-  c = arctan(ρ)
+Step 2: 投影型に応じた角距離cを計算
+  c = _pixel_radius_to_angle(r, s_rad, projection)
 
-Step 3: 球面三角法で新しい天球座標を計算
-  δ = arcsin(cos(c)·sin(δ₀) + η·sin(c)·cos(δ₀)/ρ)
-  α = α₀ + arctan2(ξ·sin(c), ρ·cos(δ₀)·cos(c) - η·sin(δ₀)·sin(c))
+Step 3: 球面三角法で天球座標を計算（投影型非依存）
+  δ = arcsin(cos(c)·sin(δ₀) + sin(c)·cos(δ₀)·cos(φ))
+  α = α₀ + arctan2(sin(c)·sin(φ), cos(c)·cos(δ₀) - sin(c)·sin(δ₀)·cos(φ))
 ```
+
+Step 3 の球面三角法は投影型に依存しません。投影型の違いは Step 2 の角距離計算のみに影響します。これにより、新しい投影型の追加は `_pixel_radius_to_angle()` と `_effective_pixel_scale_factor()` に1ケース追加するだけで済みます。
 
 **オフセット符号の注意:**
 
@@ -337,9 +377,9 @@ offset_x = image_center_x - tile_center_x   # 東方向が正
 offset_y = image_center_y - tile_center_y   # 北方向が正
 ```
 
-### 3.4 線形近似との精度比較
+### 3.5 線形近似との精度比較
 
-14mm（FOV ~147°）でのコーナータイル:
+14mm rectilinear（FOV ~147°）でのコーナータイル:
 
 | 手法 | RA誤差 | DEC誤差 |
 |------|--------|---------|
@@ -347,6 +387,24 @@ offset_y = image_center_y - tile_center_y   # 北方向が正
 | gnomonic逆投影 | < 0.1° | < 0.1° |
 
 広角画像では線形近似は全く使えず、完全な球面三角法が必須です。
+
+### 3.6 魚眼レンズの対角FOV計算
+
+`--recommend-grid` や PixInsight の推奨グリッド表示では、投影型に応じた正確な対角FOVを計算します。
+
+```
+対角ピクセル距離: r_diag = √(W² + H²) / 2
+
+gnomonic:       FOV = 2 × arctan(r_diag × s)
+equisolid:      FOV = 2 × 2 × arcsin(r_diag × s / 2)
+equidistant:    FOV = 2 × r_diag × s
+stereographic:  FOV = 2 × 2 × arctan(r_diag × s / 2)
+```
+
+例: Sigma 15mm f/2.8 Fisheye + Sony A7R IV (9533×6344, 3.76µm)
+- 中心ピクセルスケール: 51.7"/px
+- equisolid 対角FOV: **183.4°**
+- 推奨グリッド: **12x8**
 
 ---
 
@@ -851,7 +909,7 @@ split-image-solver/
 │   │   ├── astrometry_local_solver.py   # solve-field ラッパー
 │   │   └── factory.py                   # ソルバーファクトリー
 │   └── utils/
-│       ├── coordinate_transform.py      # gnomonic投影、タイルスケール計算
+│       ├── coordinate_transform.py      # 投影型対応の座標変換、タイルスケール計算
 │       ├── equipment.py                 # 機材DB操作
 │       └── logger.py                    # ロガー設定
 ├── javascript/
@@ -862,7 +920,7 @@ split-image-solver/
 │   └── settings.example.json            # 設定テンプレート
 ├── tests/
 │   └── python/
-│       ├── test_coordinate_transform.py # gnomonic投影テスト
+│       ├── test_coordinate_transform.py # 投影型対応テスト（38件）
 │       ├── test_image_splitter.py       # グリッド分割テスト
 │       ├── test_wcs_integrator.py       # WCS統合テスト
 │       ├── test_list_equipment.py       # 機材DB・推奨グリッドテスト
@@ -919,6 +977,5 @@ brew install astrometry-net netpbm
 ### 将来の改善候補
 
 1. **lensfunpy統合**: ソルブ前にレンズ歪曲収差を除去 → 精度向上
-2. **魚眼レンズ対応**: 等距離射影/等立体角射影 → gnomonic変換
-3. **自己キャリブレーション**: 成功タイルのSIPから画像全体の歪みモデルを推定
-4. **大スケール用インデックスの自動取得**: 不足インデックスの検出と推奨
+2. **自己キャリブレーション**: 成功タイルのSIPから画像全体の歪みモデルを推定
+3. **大スケール用インデックスの自動取得**: 不足インデックスの検出と推奨


### PR DESCRIPTION
## 概要
- README.mdに魚眼レンズの使用方法（CLIオプション・使用例・PixInsight設定・推奨インデックス）とATOM Cam 2制限事項を追加
- docs/specs.mdの技術仕様を4投影型（gnomonic/equisolid/equidistant/stereographic）対応に更新
- HANDOVER.mdを.gitignoreに追加

## テスト計画
- [ ] ドキュメントのみの変更のため、既存テストが引き続きパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)