### PR TITLE
doSingleSolveのself未定義エラーを修正

### DIFF
--- a/javascript/SplitImageSolver.js
+++ b/javascript/SplitImageSolver.js
@@ -3381,6 +3381,7 @@ SplitSolverDialog.prototype.doSolve = function() {
 // Single image solve (original Phase 1 flow)
 //----------------------------------------------------------------------------
 SplitSolverDialog.prototype.doSingleSolve = function(targetWindow, apiKey, hints, imageWidth, imageHeight, timeoutMs) {
+   var self = this;
    // Save image to temporary FITS
    var tmpFits = File.systemTempDirectory + "/split_solver_upload.fits";
    console.writeln("Saving temporary FITS: " + tmpFits);


### PR DESCRIPTION
## 概要
- `doSingleSolve`に`var self = this;`が欠落しており、`client.abortCheck`コールバック内で`ReferenceError: self is not defined`が発生していたバグを修正

## テスト計画
- [ ] 1x1 (Single)モードでソルブが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)