### PR TITLE
fix: IT-Solver の solve-field パス検出をポータブルに変更

### DIFF
--- a/tests/it/local/test_solver_2x2.py
+++ b/tests/it/local/test_solver_2x2.py
@@ -27,9 +27,9 @@ FIXTURE_DIR = REPO_ROOT / "tests" / "fixtures"
 CONFIG_PATH = REPO_ROOT / "config" / "settings.json"
 
 # solve-field が存在しない環境ではスキップ
+import shutil
 pytestmark = pytest.mark.skipif(
-    not Path("/opt/homebrew/bin/solve-field").exists()
-    and not Path("/usr/local/bin/solve-field").exists(),
+    shutil.which("solve-field") is None,
     reason="solve-field not found",
 )
 

--- a/tests/it/local/test_solver_8x6.py
+++ b/tests/it/local/test_solver_8x6.py
@@ -27,9 +27,9 @@ FIXTURE_DIR = REPO_ROOT / "tests" / "fixtures"
 CONFIG_PATH = REPO_ROOT / "config" / "settings.json"
 
 # solve-field が存在しない環境ではスキップ
+import shutil
 pytestmark = pytest.mark.skipif(
-    not Path("/opt/homebrew/bin/solve-field").exists()
-    and not Path("/usr/local/bin/solve-field").exists(),
+    shutil.which("solve-field") is None,
     reason="solve-field not found",
 )
 

--- a/tests/it/local/test_solver_equidistant_12x8.py
+++ b/tests/it/local/test_solver_equidistant_12x8.py
@@ -27,9 +27,9 @@ FIXTURE_DIR = REPO_ROOT / "tests" / "fixtures"
 CONFIG_PATH = REPO_ROOT / "config" / "settings.json"
 
 # solve-field が存在しない環境ではスキップ
+import shutil
 pytestmark = pytest.mark.skipif(
-    not Path("/opt/homebrew/bin/solve-field").exists()
-    and not Path("/usr/local/bin/solve-field").exists(),
+    shutil.which("solve-field") is None,
     reason="solve-field not found",
 )
 

--- a/tests/it/local/test_solver_equisolid_8x6.py
+++ b/tests/it/local/test_solver_equisolid_8x6.py
@@ -27,9 +27,9 @@ FIXTURE_DIR = REPO_ROOT / "tests" / "fixtures"
 CONFIG_PATH = REPO_ROOT / "config" / "settings.json"
 
 # solve-field が存在しない環境ではスキップ
+import shutil
 pytestmark = pytest.mark.skipif(
-    not Path("/opt/homebrew/bin/solve-field").exists()
-    and not Path("/usr/local/bin/solve-field").exists(),
+    shutil.which("solve-field") is None,
     reason="solve-field not found",
 )
 


### PR DESCRIPTION
## 概要
- IT-Solver テスト4ファイルの solve-field パス検出を macOS ハードコードパスから `shutil.which("solve-field")` に変更
- Docker 環境（`/usr/bin/solve-field`）でもテストがスキップされずに実行可能に

## テスト計画
- [x] Docker 環境で IT-Solver 2x2 が 4/4 成功を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)